### PR TITLE
feat/Implemented the learning path service

### DIFF
--- a/src/api/requestHandlers/learningPath.ts
+++ b/src/api/requestHandlers/learningPath.ts
@@ -1,0 +1,124 @@
+import { RequestHandler } from 'express';
+import { responseHandler } from '../../core/helpers/utilities';
+import LearningPathController from '../../../src/core/controllers/learningPath';
+import BadRequestError from '../../core/errors/BadRequestError';
+
+class LearningPathRequestHandler {
+  private learningPathController: LearningPathController;
+
+  constructor(_learningPathController: LearningPathController) {
+    this.learningPathController = _learningPathController;
+  }
+
+  createLearningPath: RequestHandler = async (req, res, next) => {
+    try {
+      const newLearningPath = await this.learningPathController.createLearningPath(req.body);
+      res.json(responseHandler(newLearningPath, 'Learning path created successfully'));
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  getLearningPathById: RequestHandler = async (req, res, next) => {
+    try {
+      const learningPath = await this.learningPathController.getLearningPathById(req.params.id);
+      res.json(responseHandler(learningPath, 'Learning path fetched successfully'));
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  getAllLearningPaths: RequestHandler = async (req, res, next) => {
+    try {
+      const learningPaths = await this.learningPathController.getAllLearningPaths();
+      res.json(responseHandler(learningPaths, 'Learning paths fetched successfully'));
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  updateLearningPath: RequestHandler = async (req, res, next) => {
+    try {
+      const updatedLearningPath = await this.learningPathController.updateLearningPath(req.params.id, req.body);
+      res.json(responseHandler(updatedLearningPath, 'Learning path updated successfully'));
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  deleteLearningPath: RequestHandler = async (req, res, next) => {
+    try {
+      const result = await this.learningPathController.deleteLearningPath(req.params.id);
+      res.json(responseHandler(result, 'Learning path deleted successfully'));
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  addLessons: RequestHandler = async (req, res, next) => {
+    try {
+      const lessons = await this.learningPathController.addLessons(req.params.id as string, req.body);
+      res.json(responseHandler(lessons, 'Lesson added successfully'));
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  bulkAddLessonsFromExcel: RequestHandler = async (req, res, next) => {
+    try {
+      const file = req.file;
+      if (!file || !file.buffer) {
+        throw new BadRequestError({ message: 'Excel file buffer missing' });
+      }
+
+      const result = await this.learningPathController.bulkAddLessonsFromExcel(req.params.id as string, file.buffer);
+
+      res.json(
+        responseHandler(
+          { created: result.created.length, duplicates: result.duplicates.length, invalidRows: result.invalidRows.length, result },
+          'Bulk users processed'
+        )
+      );
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  getLessons: RequestHandler = async (req, res, next) => {
+    try {
+      const lessons = await this.learningPathController.getLessons(req.params.id as string);
+      res.json(responseHandler(lessons, 'Lessons fetched successfully'));
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  lessonToggle: RequestHandler = async (req, res, next) => {
+    try {
+      const toggledLesson = await this.learningPathController.lessonToggle(req.params.id as string, req.params.lessonId as string);
+      res.json(responseHandler(toggledLesson, 'Lesson completion status toggled successfully'));
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  updateLesson: RequestHandler = async (req, res, next) => {
+    try {
+      const updatedLesson = await this.learningPathController.updateLesson(req.params.id as string, req.params.lessonId as string, req.body);
+      res.json(responseHandler(updatedLesson, 'Lesson updated successfully'));
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  deleteLesson: RequestHandler = async (req, res, next) => {
+    try {
+      const result = await this.learningPathController.deleteLesson(req.params.id as string, req.params.lessonId as string);
+      res.json(responseHandler({ message: result }, 'Lesson deleted successfully'));
+    } catch (error) {
+      next(error);
+    }
+  };
+}
+
+export default LearningPathRequestHandler;

--- a/src/api/routes/Base.ts
+++ b/src/api/routes/Base.ts
@@ -2,11 +2,13 @@ import { Router } from 'express';
 import authRoute from './user';
 import adminRoute from './admin';
 import classRoute from './class';
+import learningPathRoute from './learningPath';
 
 const baseRoute = Router();
 
 baseRoute.use('/auth/users', authRoute);
 baseRoute.use('/auth/admins', adminRoute);
 baseRoute.use('/classes', classRoute);
+baseRoute.use('/learning-path', learningPathRoute);
 
 export default baseRoute;

--- a/src/api/routes/learningPath.ts
+++ b/src/api/routes/learningPath.ts
@@ -1,0 +1,44 @@
+import { Router } from 'express';
+import LearningPathRequestHandler from '../requestHandlers/learningPath';
+import { learningPathCreationSchema, lessonSchema, learningPathUpdateSchema } from '../../../src/core/validations/learningPath';
+import { SEGMENT, validationWrapper } from '../../../src/core/helpers/validators';
+import LearningPathController from '../../../src/core/controllers/learningPath';
+import { authenticate } from '../middlewares/authentication';
+import { authorize } from '../middlewares/authorization';
+import { uploadExcel } from '../../../src/core/config/multer';
+
+const router = Router();
+const learningPathController = new LearningPathController();
+const learningPathRequestHandler = new LearningPathRequestHandler(learningPathController);
+
+router.post(
+  '/',
+  validationWrapper(SEGMENT.BODY, learningPathCreationSchema),
+  authenticate,
+  authorize('admin'),
+  learningPathRequestHandler.createLearningPath
+);
+router.get('/:id', authenticate, learningPathRequestHandler.getLearningPathById);
+router.get('/', authenticate, learningPathRequestHandler.getAllLearningPaths);
+router.put(
+  '/:id',
+  authenticate,
+  authorize('admin'),
+  validationWrapper(SEGMENT.BODY, learningPathUpdateSchema),
+  learningPathRequestHandler.updateLearningPath
+);
+router.delete('/:id', authenticate, authorize('admin'), learningPathRequestHandler.deleteLearningPath);
+router.post('/:id/lessons', validationWrapper(SEGMENT.BODY, lessonSchema), authenticate, authorize('admin'), learningPathRequestHandler.addLessons);
+router.get('/:id/lessons', authenticate, learningPathRequestHandler.getLessons);
+router.patch(
+  '/:id/lessons/:lessonId',
+  validationWrapper(SEGMENT.BODY, learningPathUpdateSchema),
+  authenticate,
+  authorize('admin'),
+  learningPathRequestHandler.updateLesson
+);
+router.put('/:id/lessons/:lessonId', authenticate, authorize('admin', 'instructor'), learningPathRequestHandler.lessonToggle);
+router.delete('/:id/lessons/:lessonId', authenticate, authorize('admin'), learningPathRequestHandler.deleteLesson);
+router.post('/:id/lessons/bulk', authenticate, authorize('admin'), uploadExcel.single('file'), learningPathRequestHandler.bulkAddLessonsFromExcel);
+
+export default router;

--- a/src/core/controllers/learningPath.ts
+++ b/src/core/controllers/learningPath.ts
@@ -1,0 +1,129 @@
+import { ILearningPath, ILessons, ILearningPathModel, IBulkResult } from '../interfaces/learningPath';
+import BadRequestError from '../errors/BadRequestError';
+import ResourceNotFoundError from '../errors/ResourceNotFoundError';
+import LearningPathService from '../services/learningPath';
+import { LearningPathRepository } from '../repositories/LearningPathRepository';
+
+class LearningPathController {
+  private learningPathRepository: LearningPathRepository;
+  private learningPathService: LearningPathService;
+
+  constructor() {
+    this.learningPathRepository = new LearningPathRepository();
+    this.learningPathService = new LearningPathService(this.learningPathRepository);
+  }
+
+  async createLearningPath(payload: Omit<ILearningPath, '_id'>): Promise<ILearningPath> {
+    return await this.learningPathService.createLearningPath(payload);
+  }
+
+  async getLearningPathById(id: string): Promise<ILearningPath | null> {
+    const LearningPath = await this.learningPathService.getLearningPathById(id);
+    if (!LearningPath) {
+      throw new ResourceNotFoundError({ message: 'Learning path not found', reason: 'Invalid learning path ID' });
+    }
+    return LearningPath;
+  }
+
+  async getAllLearningPaths(): Promise<ILearningPath[]> {
+    const learningPaths = await this.learningPathService.getAllLearningPaths();
+    if (learningPaths.length === 0) {
+      throw new ResourceNotFoundError({ message: 'No learning paths found', reason: 'No learning paths available' });
+    }
+    return learningPaths;
+  }
+
+  async updateLearningPath(id: string, payload: Partial<ILearningPathModel>): Promise<ILearningPath | null> {
+    const existing = await this.learningPathService.getLearningPathById(id);
+    if (!existing) {
+      throw new ResourceNotFoundError({ message: 'Learning path not found', reason: 'Invalid learning path ID' });
+    }
+    return await this.learningPathService.updateLearningPath(id, payload);
+  }
+
+  async deleteLearningPath(id: string): Promise<{ deletedCount: number }> {
+    const existing = await this.learningPathService.getLearningPathById(id);
+    if (!existing) {
+      throw new ResourceNotFoundError({ message: 'Learning path not found', reason: 'Invalid learning path ID' });
+    }
+    return await this.learningPathService.deleteLearningPath(id);
+  }
+
+  async addLessons(learningPathId: string, lessons: Omit<ILessons, '_id' | 'completed'>): Promise<ILessons[] | null> {
+    const learningPath = await this.learningPathService.getLearningPathById(learningPathId);
+    if (!learningPath) {
+      throw new ResourceNotFoundError({ message: 'Learning path not found', reason: 'Invalid learning path ID' });
+    }
+    const existingWeeks = new Set<number>(learningPath.lessons.map((l: any) => Number(l.week)));
+    if (existingWeeks.has(lessons.week)) {
+      throw new BadRequestError({ message: `Lesson for week ${lessons.week} already exists`, reason: 'Duplicate week number' });
+    }
+    const payload: Omit<ILessons, '_id' | 'completed'>[] = [];
+    payload.push(lessons);
+    return await this.learningPathService.addLessons(learningPathId, payload);
+  }
+
+  async bulkAddLessonsFromExcel(learningPathId: string, fileBuffer: Buffer): Promise<IBulkResult> {
+    const learningPath = await this.learningPathService.getLearningPathById(learningPathId);
+    if (!learningPath) {
+      throw new ResourceNotFoundError({ message: 'Learning path not found', reason: 'Invalid learning path ID' });
+    }
+    return await this.learningPathService.bulkAddLessonsFromExcel(learningPathId, fileBuffer);
+  }
+
+  async getLessons(learningPathId: string): Promise<ILessons[] | null> {
+    const learningPath = await this.learningPathService.getLearningPathById(learningPathId);
+    if (!learningPath) {
+      throw new ResourceNotFoundError({ message: 'Learning path not found', reason: 'Invalid learning path ID' });
+    }
+    const lessons = await this.learningPathService.getLessons(learningPathId);
+    if (!lessons || lessons.length === 0) {
+      throw new ResourceNotFoundError({ message: 'No lessons found', reason: 'No lessons available for this learning path' });
+    }
+    return lessons;
+  }
+
+  async lessonToggle(learningPathId: string, lessonId: string): Promise<ILessons | null> {
+    const learningPath = await this.learningPathService.getLearningPathById(learningPathId);
+    if (!learningPath) {
+      throw new ResourceNotFoundError({ message: 'Learning path not found', reason: 'Invalid learning path ID' });
+    }
+    const lesson = learningPath.lessons.find((l: any) => l._id.toString() === lessonId);
+    if (!lesson) {
+      throw new ResourceNotFoundError({ message: 'Lesson not found', reason: 'Invalid lesson ID' });
+    }
+    return await this.learningPathService.LessonToggle(learningPathId, lessonId);
+  }
+
+  async updateLesson(learningPathId: string, lessonId: string, payload: Partial<Omit<ILessons, '_id' | 'completed'>>): Promise<ILessons | null> {
+    const learningPath = await this.learningPathService.getLearningPathById(learningPathId);
+    if (!learningPath) {
+      throw new ResourceNotFoundError({ message: 'Learning path not found', reason: 'Invalid learning path ID' });
+    }
+    const lesson = learningPath.lessons.find((l: any) => l._id.toString() === lessonId);
+    if (!lesson) {
+      throw new ResourceNotFoundError({ message: 'Lesson not found', reason: 'Invalid lesson ID' });
+    }
+    if (payload.week && payload.week !== lesson.week) {
+      const existingWeeks = new Set<number>(learningPath.lessons.map((l: any) => Number(l.week)));
+      if (existingWeeks.has(payload.week)) {
+        throw new BadRequestError({ message: `Lesson for week ${payload.week} already exists`, reason: 'Duplicate week number' });
+      }
+    }
+    return await this.learningPathService.updateLesson(learningPathId, lessonId, payload);
+  }
+
+  async deleteLesson(learningPathId: string, lessonId: string): Promise<string | null> {
+    const learningPath = await this.learningPathService.getLearningPathById(learningPathId);
+    if (!learningPath) {
+      throw new ResourceNotFoundError({ message: 'Learning path not found', reason: 'Invalid learning path ID' });
+    }
+    const lesson = learningPath.lessons.find((l: any) => l._id.toString() === lessonId);
+    if (!lesson) {
+      throw new ResourceNotFoundError({ message: 'Lesson not found', reason: 'Invalid lesson ID' });
+    }
+    return await this.learningPathService.deleteLesson(learningPathId, lessonId);
+  }
+}
+
+export default LearningPathController;

--- a/src/core/interfaces/learningPath.ts
+++ b/src/core/interfaces/learningPath.ts
@@ -1,0 +1,25 @@
+import { Document, Types } from 'mongoose';
+
+export interface ILessons {
+  _id: string;
+  week: number;
+  title: string;
+  description: string;
+  completed: boolean;
+}
+
+export interface ILessonsModel extends Omit<ILessons, '_id'>, Document {}
+
+export interface ILearningPath {
+  _id: string;
+  stack: string;
+  Instructor: string;
+  lessons: Types.DocumentArray<ILessons>;
+}
+export interface ILearningPathModel extends Omit<ILearningPath, '_id'>, Document {}
+
+export interface IBulkResult {
+  created: ILessons[];
+  duplicates: number[];
+  invalidRows: any[];
+}

--- a/src/core/models/learningPath.ts
+++ b/src/core/models/learningPath.ts
@@ -1,0 +1,23 @@
+import mongoose, { Schema } from 'mongoose';
+import { ILearningPathModel, ILessonsModel } from '../interfaces/learningPath';
+
+const LessonsSchema: Schema = new Schema<ILessonsModel>(
+  {
+    week: { type: Number, required: true },
+    title: { type: String, required: true },
+    description: { type: String, required: true },
+    completed: { type: Boolean, default: false }
+  },
+  { _id: true }
+);
+
+const LearningPathSchema: Schema = new Schema(
+  {
+    stack: { type: String, required: true },
+    Instructor: { type: String, required: true },
+    lessons: { type: [LessonsSchema], default: [] }
+  },
+  { timestamps: true }
+);
+
+export const LearningPath = mongoose.model<ILearningPathModel>('learningPaths', LearningPathSchema);

--- a/src/core/repositories/LearningPathRepository.ts
+++ b/src/core/repositories/LearningPathRepository.ts
@@ -1,0 +1,94 @@
+import { FilterQuery } from 'mongoose';
+import { ILessons, ILearningPath, ILearningPathModel, ILessonsModel } from '../interfaces/learningPath';
+import { LearningPath } from '../models/learningPath';
+
+export class LearningPathRepository {
+  async createLearningPath(payload: Omit<ILearningPath, '_id'>): Promise<ILearningPath> {
+    const learningPath = await LearningPath.create(payload);
+    return this.convertToILearningPath(learningPath);
+  }
+
+  async findLearningPathById(id: string): Promise<ILearningPath | null> {
+    const learningPath = await LearningPath.findById(id);
+    return learningPath ? this.convertToILearningPath(learningPath) : null;
+  }
+
+  async findLearningPaths(filter: FilterQuery<ILearningPathModel> = {}): Promise<ILearningPath[]> {
+    const learningPaths = await LearningPath.find(filter);
+    return learningPaths.map((lp) => this.convertToILearningPath(lp));
+  }
+
+  async updateLearningPath(id: string, payload: Partial<ILearningPathModel>): Promise<ILearningPath | null> {
+    const learningPath = await LearningPath.findByIdAndUpdate(id, payload, { new: true });
+    return learningPath ? this.convertToILearningPath(learningPath) : null;
+  }
+
+  async deleteLearningPath(id: string): Promise<{ deletedCount: number }> {
+    const result = await LearningPath.deleteMany({ _id: id });
+    return { deletedCount: result.deletedCount };
+  }
+
+  async createLessons(learningPathId: string, payload: Omit<ILessons, '_id' | 'completed'>[]): Promise<ILessons[] | null> {
+    const learningPath = await LearningPath.findById(learningPathId);
+    if (!learningPath) return null;
+    learningPath.lessons.push(...payload);
+    await learningPath.save();
+    const lessons = learningPath.lessons.map((ls) => this.convertToILessons(ls)).sort((a, b) => a.week - b.week);
+    return lessons;
+  }
+
+  async getLessons(learningPathId: string): Promise<ILessons[] | null> {
+    const learningPath = await LearningPath.findById(learningPathId);
+    if (!learningPath) return null;
+    const lessons = learningPath.lessons.map((ls) => this.convertToILessons(ls)).sort((a, b) => a.week - b.week);
+    return lessons;
+  }
+
+  async toggleLessonCompleted(learningPathId: string, lessonId: string): Promise<ILessons | null> {
+    const learningPath = await LearningPath.findById(learningPathId);
+    if (!learningPath) return null;
+    const lesson = learningPath.lessons.id(lessonId);
+    if (!lesson) return null;
+    lesson.completed = !lesson.completed;
+    await learningPath.save();
+    return lesson;
+  }
+
+  async updateLessons(learningPathId: string, lessonId: string, payload: Partial<Omit<ILessons, '_id' | 'completed'>>): Promise<ILessons | null> {
+    const learningPath = await LearningPath.findById(learningPathId);
+    if (!learningPath) return null;
+    const lesson = learningPath.lessons.id(lessonId);
+    if (!lesson) return null;
+    lesson.set(payload);
+    await learningPath.save();
+    return lesson;
+  }
+
+  async deleteLesson(learningPathId: string, lessonId: string): Promise<string | null> {
+    const learningPath = await LearningPath.findById(learningPathId);
+    if (!learningPath) return null;
+    const lesson = learningPath.lessons.id(lessonId);
+    lesson.deleteOne();
+    await learningPath.save();
+    return 'Lesson deleted successfully';
+  }
+
+  private convertToILearningPath(learningPath: ILearningPathModel): ILearningPath {
+    return {
+      _id: learningPath._id.toString(),
+      stack: learningPath.stack,
+      Instructor: learningPath.Instructor,
+      lessons: learningPath.lessons
+    };
+  }
+
+  private convertToILessons(lesson: ILessonsModel): ILessons {
+    return {
+      _id: lesson._id.toString(),
+      week: lesson.week,
+      title: lesson.title,
+      description: lesson.description,
+      completed: lesson.completed
+    };
+  }
+}

--- a/src/core/services/learningPath.ts
+++ b/src/core/services/learningPath.ts
@@ -1,0 +1,169 @@
+import { FilterQuery } from 'mongoose';
+import { ILearningPath, ILessons, ILearningPathModel, IBulkResult } from '../interfaces/learningPath';
+import * as XLSX from 'xlsx';
+import { LearningPathRepository } from '../repositories/LearningPathRepository';
+import { bulkLessonsSchema } from '../validations/learningPath';
+import BadRequestError from '../errors/BadRequestError';
+import ResourceNotFoundError from '../errors/ResourceNotFoundError';
+
+class LearningPathService {
+  private learningPathRepository: LearningPathRepository;
+
+  constructor(_learningPathRepository: LearningPathRepository) {
+    this.learningPathRepository = _learningPathRepository;
+  }
+
+  async createLearningPath(payload: Omit<ILearningPath, '_id'>): Promise<ILearningPath> {
+    return await this.learningPathRepository.createLearningPath(payload);
+  }
+
+  async getLearningPathById(id: string): Promise<ILearningPath | null> {
+    return await this.learningPathRepository.findLearningPathById(id);
+  }
+
+  async getAllLearningPaths(filter?: FilterQuery<ILearningPathModel>): Promise<ILearningPath[]> {
+    return await this.learningPathRepository.findLearningPaths(filter);
+  }
+
+  async updateLearningPath(id: string, payload: Partial<ILearningPathModel>): Promise<ILearningPath | null> {
+    return await this.learningPathRepository.updateLearningPath(id, payload);
+  }
+
+  async deleteLearningPath(id: string): Promise<{ deletedCount: number }> {
+    return await this.learningPathRepository.deleteLearningPath(id);
+  }
+
+  async addLessons(learningPathId: string, lessons: Omit<ILessons, '_id' | 'completed'>[]): Promise<ILessons[] | null> {
+    return await this.learningPathRepository.createLessons(learningPathId, lessons);
+  }
+
+  async getLessons(learningPathId: string): Promise<ILessons[] | null> {
+    return await this.learningPathRepository.getLessons(learningPathId);
+  }
+
+  async LessonToggle(learningPathId: string, lessonId: string): Promise<ILessons | null> {
+    return await this.learningPathRepository.toggleLessonCompleted(learningPathId, lessonId);
+  }
+
+  async updateLesson(learningPathId: string, lessonId: string, payload: Partial<Omit<ILessons, '_id' | 'completed'>>): Promise<ILessons | null> {
+    return await this.learningPathRepository.updateLessons(learningPathId, lessonId, payload);
+  }
+
+  async deleteLesson(learningPathId: string, lessonId: string): Promise<string | null> {
+    return await this.learningPathRepository.deleteLesson(learningPathId, lessonId);
+  }
+
+  async bulkAddLessonsFromExcel(learningPathId: string, fileBuffer: Buffer): Promise<IBulkResult> {
+    if (!fileBuffer) throw new BadRequestError({ message: 'Excel file is required', reason: 'No file uploaded' });
+
+    const rawRows = this.extractRows(fileBuffer);
+    if (!rawRows.length) throw new BadRequestError({ message: 'No rows found in sheet', reason: 'Empty sheet' });
+
+    const { formattedLessons, invalidRows, invalidSet } = this.normalizeLessonRows(rawRows);
+
+    if (!formattedLessons.length) throw new BadRequestError({ message: 'No valid rows found in sheet', reason: 'All rows are invalid' });
+
+    let validLessons: any[] = [];
+    const parseResult = bulkLessonsSchema.safeParse(formattedLessons);
+
+    if (parseResult.success) {
+      validLessons = parseResult.data;
+      console.log('✅ Valid lessons:', validLessons.length);
+    } else {
+      console.log('❌ Zod validation failed for lessons:', parseResult.error.errors);
+
+      for (const issue of parseResult.error.errors) {
+        const index = typeof issue.path[0] === 'number' ? issue.path[0] : -1;
+        const row = formattedLessons[index];
+        if (row && !invalidSet.has(`${row.week}-${row.title}`)) {
+          invalidRows.push({
+            ...row,
+            reason: issue.message
+          });
+          invalidSet.add(`${row.week}-${row.title}`);
+        }
+      }
+
+      const invalidKeys = new Set(invalidRows.map((u) => `${u.week}-${u.title}`));
+      validLessons = formattedLessons.filter((u) => !invalidKeys.has(`${u.week}-${u.title}`));
+    }
+
+    const learningPath = await this.learningPathRepository.findLearningPathById(learningPathId);
+    if (!learningPath) throw new ResourceNotFoundError({ message: 'Learning path not found', reason: 'Invalid learning path ID' });
+
+    const existingWeeks = new Set<number>(learningPath.lessons.map((l: any) => Number(l.week)));
+    const duplicates: number[] = [];
+    const lessonsToAdd: Omit<ILessons, '_id' | 'completed'>[] = [];
+
+    for (const lesson of validLessons) {
+      const weekNum = Number(lesson.week);
+      if (existingWeeks.has(weekNum)) {
+        duplicates.push(weekNum);
+      } else {
+        lessonsToAdd.push({
+          week: weekNum,
+          title: lesson.title,
+          description: lesson.description
+        });
+        existingWeeks.add(weekNum);
+      }
+    }
+
+    const created = (await this.learningPathRepository.createLessons(learningPathId, lessonsToAdd)) || [];
+
+    return { created, duplicates, invalidRows };
+  }
+
+  private extractRows(buffer: Buffer): any[] {
+    const workbook = XLSX.read(buffer, { type: 'buffer' });
+    const sheet = workbook.Sheets[workbook.SheetNames[0]];
+    return XLSX.utils.sheet_to_json(sheet, { defval: '' });
+  }
+
+  private normalizeLessonRows(rawRows: any[]): { formattedLessons: any[]; invalidRows: any[]; invalidSet: Set<string> } {
+    const formattedLessons: any[] = [];
+    const invalidRows: any[] = [];
+    const invalidSet = new Set<string>();
+
+    for (const row of rawRows) {
+      const normalized: Record<string, any> = {};
+      for (const key in row) {
+        normalized[key.toLowerCase().trim()] = row[key];
+      }
+
+      const weekRaw = normalized['week'] ?? normalized['week number'] ?? normalized['week_no'] ?? normalized['wk'] ?? '';
+      const title = (normalized['title'] ?? normalized['lesson title'] ?? normalized['name'] ?? '').toString().trim();
+      const description = (normalized['description'] ?? normalized['details'] ?? normalized['lesson description'] ?? '').toString().trim();
+
+      let week: number | null = null;
+      if (weekRaw !== '' && weekRaw !== null && weekRaw !== undefined) {
+        const n = Number(weekRaw);
+        week = Number.isFinite(n) ? Math.trunc(n) : null;
+      }
+
+      if (week === null || !title || !description) {
+        const ident = `${week ?? 'no-week'}-${title || 'no-title'}`;
+        if (!invalidSet.has(ident)) {
+          invalidRows.push({
+            raw: row,
+            week: weekRaw,
+            title,
+            description
+          });
+          invalidSet.add(ident);
+        }
+        continue;
+      }
+
+      formattedLessons.push({
+        week,
+        title,
+        description
+      });
+    }
+
+    return { formattedLessons, invalidRows, invalidSet };
+  }
+}
+
+export default LearningPathService;

--- a/src/core/validations/learningPath.ts
+++ b/src/core/validations/learningPath.ts
@@ -1,0 +1,27 @@
+import z from 'zod';
+
+export const learningPathCreationSchema = z.object({
+  stack: z.string().trim().min(1, 'Stack is required').max(50, 'Stack must be at most 50 characters long'),
+  Instructor: z.string().trim().min(1, 'Instructor is required').max(100, 'Instructor must be at most 100 characters long')
+});
+
+export const lessonSchema = z.object({
+  week: z
+    .number()
+    .int()
+    .positive('Week must be a positive integer')
+    .refine((n) => Number.isInteger(n), { message: 'Week must be an integer' }),
+  title: z.string().trim().min(1, 'Title is required').max(200, 'Title too long'),
+  description: z.string().trim().min(1, 'Description is required')
+});
+
+export const bulkLessonsSchema = z
+  .array(lessonSchema)
+  .nonempty('At least one lesson is required')
+  .max(50, 'Maximum 50 lessons can be uploaded at once');
+
+export const combinedCreationSchema = learningPathCreationSchema.merge(lessonSchema);
+
+export const learningPathUpdateSchema = combinedCreationSchema.partial().refine((data) => Object.keys(data).length > 0, {
+  message: 'At least one field must be provided for update'
+});


### PR DESCRIPTION
#### WHY THIS PR?
<sub>
Adds a Learning Path feature so instructors can create learning paths composed of ordered lessons — needed to model course content in the product.

Implements UX/back-end requirements: create/update/delete learning paths, add single/multiple lessons (including Excel bulk import), prevent scheduling overlaps, and toggle lesson completion.
</sub>

#### WHAT DOES THIS PR DO?
<sub>
Adds LearningPath model with an embedded lessons subdocument schema (each lesson has its own _id).

Implements CRUD for learning paths and lessons, including:

single lesson create / update / delete,

bulk lessons import from Excel (normalizes rows, validates, ignores irrelevant columns, skips duplicates),

toggle lesson completed endpoint that flips the boolean and returns the updated lessons list.
</sub>

#### HOW CAN THIS PR BE TESTED?
<sub>
Navigate to the e-lerning on the postman workspace, then open the Admin endpoint (local/live), then click on the Learning Path and you find all endpoint configured
</sub>

#### THINGS YOU MAY WANT THE REVIEWER TO NOTE.
<sub>
Embedded lessons: lessons are subdocuments (each with _id). Deleting the parent deletes lessons automatically.

Defaults: completed is intentionally omitted from client input and relies on the schema default false (we ignore any completed column from Excel).

Bulk import behavior: duplicate detection uses week by default (easy to switch to title or composite key). Invalid rows are returned with row indices for easy repair.
</sub>
